### PR TITLE
Add EvoSkills co-evolutionary skill evolution (Zhang et al., arXiv:2604.01687)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Cross-Review MCP Broker
 
-MCP server enabling two Claude Code instances to review each other's projects through structured artifact exchange. Design informed by QSG scaling laws (Tanaka, arXiv:2603.24676).
+MCP server enabling two Claude Code instances to review each other's projects through structured artifact exchange. Design informed by QSG scaling laws (Tanaka, arXiv:2603.24676) and EvoSkills co-evolutionary verification (Zhang et al., arXiv:2604.01687).
 
 ## Quick Start
 
@@ -19,6 +19,7 @@ Single-process HTTP server with in-memory state. Two Claude Code instances conne
 - **Task queues**: per-agent message buffers (send_task / poll_tasks)
 - **Phase signaling**: lifecycle coordination with blocking wait (signal_phase / wait_for_phase)
 - **Bandwidth enforcement**: review bundles must contain ≥ 5 findings (QSG constraint, Γ_h ≈ 1.67)
+- **Skill evolution**: agents exchange multi-file skill packages and co-evolve them via surrogate verification (EvoSkills)
 
 ## QSG Theory (Tanaka, 2026)
 
@@ -30,6 +31,18 @@ The drift-selection parameter Γ_h = mN·h/α determines whether multi-agent agr
 - **h** = systematic bias (domain expertise)
 
 With N=2 and m ≥ 5, the system stays safely in the selection regime (Γ_h ≈ 1.67).
+
+## EvoSkills Theory (Zhang et al., 2026)
+
+EvoSkills enables agents to autonomously construct and refine multi-file skill packages through co-evolutionary verification. The two-agent cross-review topology maps naturally onto this:
+
+- **Skill Generator**: One agent creates a skill package (≥ 2 artifacts) and sends it to the peer
+- **Surrogate Verifier**: The peer synthesizes test cases and returns a verification score + feedback
+- **Co-evolution**: The generator refines the skill using feedback, up to 5 rounds
+- **Convergence**: When consecutive scores stabilize (Δ < 0.05), the skill is considered converged
+- **Cross-model transfer**: Evolved skills transfer effectively across different LLMs (35–45pp gains)
+
+Task types: `skill_bundle` (generator → verifier) and `skill_verification` (verifier → generator).
 
 ## CLI Orchestrator
 

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -11,8 +11,17 @@ import type {
   FindingResponse,
   Phase,
   PhaseWaiter,
+  SkillPackage,
+  SkillVerification,
+  SkillEvolutionState,
 } from "./types.js";
-import { PHASES, MIN_BANDWIDTH } from "./types.js";
+import {
+  PHASES,
+  MIN_BANDWIDTH,
+  MAX_EVOLUTION_ROUNDS,
+  MIN_SKILL_ARTIFACTS,
+  SKILL_CONVERGENCE_THRESHOLD,
+} from "./types.js";
 
 export interface ToolResult {
   [key: string]: unknown;
@@ -158,6 +167,65 @@ export function handleSendTask(
         error: "Response must contain at least one FindingResponse",
         received: receivedDescription,
       });
+    }
+  }
+
+  if (type === "skill_bundle") {
+    const pkg = parsedPayload as Partial<SkillPackage>;
+    if (!pkg.skillId || !pkg.name || !Array.isArray(pkg.artifacts)) {
+      return textResult({
+        error: "Skill bundle must include skillId, name, and artifacts array",
+      });
+    }
+    if (pkg.artifacts.length < MIN_SKILL_ARTIFACTS) {
+      return textResult({
+        error: `Skill packages must contain at least ${MIN_SKILL_ARTIFACTS} artifacts (EvoSkills multi-file constraint)`,
+        received: pkg.artifacts.length,
+        required: MIN_SKILL_ARTIFACTS,
+      });
+    }
+    const round = pkg.evolutionRound ?? 0;
+    if (round >= MAX_EVOLUTION_ROUNDS) {
+      return textResult({
+        error: `Skill has reached maximum evolution rounds (${MAX_EVOLUTION_ROUNDS})`,
+        currentRound: round,
+        maxRounds: MAX_EVOLUTION_ROUNDS,
+      });
+    }
+    // Initialize or update evolution state for the sender
+    const evoState = state.skillEvolution.get(from) ?? {
+      agentId: from,
+      currentRound: 0,
+      skillHistory: [],
+      converged: false,
+    };
+    evoState.currentRound = round;
+    state.skillEvolution.set(from, evoState);
+  }
+
+  if (type === "skill_verification") {
+    const ver = parsedPayload as Partial<SkillVerification>;
+    if (!ver.skillId || ver.pass === undefined || ver.score === undefined) {
+      return textResult({
+        error: "Skill verification must include skillId, pass, and score",
+      });
+    }
+    if (ver.score < 0 || ver.score > 1) {
+      return textResult({
+        error: "Verification score must be between 0 and 1",
+        received: ver.score,
+      });
+    }
+    // Update evolution state for the skill owner (the target agent)
+    const evoState = state.skillEvolution.get(to);
+    if (evoState) {
+      evoState.skillHistory.push({ skillId: ver.skillId, score: ver.score });
+      // Check convergence: last two scores within threshold
+      const history = evoState.skillHistory;
+      if (history.length >= 2) {
+        const delta = Math.abs(history[history.length - 1].score - history[history.length - 2].score);
+        evoState.converged = delta < SKILL_CONVERGENCE_THRESHOLD;
+      }
     }
   }
 
@@ -366,5 +434,40 @@ export function handleGetStatus(state: BrokerState): ToolResult {
     agents,
     minBandwidth: MIN_BANDWIDTH,
     qsgNote: `Γ_h = mN·h/α — keep m ≥ ${MIN_BANDWIDTH} to stay in selection regime`,
+  });
+}
+
+export function handleGetSkillStatus(
+  state: BrokerState,
+  args: { agentId: string },
+): ToolResult {
+  const { agentId } = args;
+
+  if (!state.agents.has(agentId)) {
+    return textResult({ error: "Agent not registered", agentId });
+  }
+
+  const evoState = state.skillEvolution.get(agentId);
+  if (!evoState) {
+    return textResult({
+      agentId,
+      hasSkillEvolution: false,
+      hint: "Submit a skill_bundle via send_task to begin co-evolutionary skill refinement",
+    });
+  }
+
+  const latestScore = evoState.skillHistory.length > 0
+    ? evoState.skillHistory[evoState.skillHistory.length - 1].score
+    : null;
+
+  return textResult({
+    agentId,
+    hasSkillEvolution: true,
+    currentRound: evoState.currentRound,
+    maxRounds: MAX_EVOLUTION_ROUNDS,
+    converged: evoState.converged,
+    latestScore,
+    totalIterations: evoState.skillHistory.length,
+    history: evoState.skillHistory,
   });
 }

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -66,6 +66,84 @@ export function notifyPhaseWaiters(state: BrokerState, agentId: string, phase: P
   state.phaseWaiters.set(agentId, remaining);
 }
 
+// --- EvoSkills validators (extracted for readability) ---
+
+function validateSkillBundle(
+  state: BrokerState,
+  senderId: string,
+  parsedPayload: unknown,
+): ToolResult | null {
+  const pkg = parsedPayload as Partial<SkillPackage>;
+  if (!pkg.skillId || !pkg.name || !Array.isArray(pkg.artifacts)) {
+    return textResult({
+      error: "Skill bundle must include skillId, name, and artifacts array",
+    });
+  }
+  if (pkg.artifacts.length < MIN_SKILL_ARTIFACTS) {
+    return textResult({
+      error: `Skill packages must contain at least ${MIN_SKILL_ARTIFACTS} artifacts (EvoSkills multi-file constraint)`,
+      received: pkg.artifacts.length,
+      required: MIN_SKILL_ARTIFACTS,
+    });
+  }
+  // Rounds are 0-indexed: round 0..MAX_EVOLUTION_ROUNDS-1 = MAX_EVOLUTION_ROUNDS total
+  const round = pkg.evolutionRound ?? 0;
+  if (round >= MAX_EVOLUTION_ROUNDS) {
+    return textResult({
+      error: `Skill has reached maximum evolution rounds (${MAX_EVOLUTION_ROUNDS})`,
+      currentRound: round,
+      maxRounds: MAX_EVOLUTION_ROUNDS,
+    });
+  }
+  // Initialize or update evolution state for the sender (skill generator)
+  const evoState = state.skillEvolution.get(senderId) ?? {
+    agentId: senderId,
+    currentRound: 0,
+    skillHistory: [],
+    converged: false,
+  };
+  evoState.currentRound = round;
+  state.skillEvolution.set(senderId, evoState);
+  return null;
+}
+
+function validateSkillVerification(
+  state: BrokerState,
+  skillOwnerId: string,
+  parsedPayload: unknown,
+): ToolResult | null {
+  const ver = parsedPayload as Partial<SkillVerification>;
+  if (!ver.skillId || ver.pass === undefined || ver.score === undefined) {
+    return textResult({
+      error: "Skill verification must include skillId, pass, and score",
+    });
+  }
+  if (ver.score < 0 || ver.score > 1) {
+    return textResult({
+      error: "Verification score must be between 0 and 1",
+      received: ver.score,
+    });
+  }
+  // Update evolution state for the skill owner (the target agent who sent the bundle)
+  // Initialize if not yet present (handles case where verification arrives before
+  // the owner's evolution state was visible to the verifier)
+  const evoState = state.skillEvolution.get(skillOwnerId) ?? {
+    agentId: skillOwnerId,
+    currentRound: 0,
+    skillHistory: [],
+    converged: false,
+  };
+  evoState.skillHistory.push({ skillId: ver.skillId, score: ver.score });
+  // Check convergence: last two scores within threshold
+  const history = evoState.skillHistory;
+  if (history.length >= 2) {
+    const delta = Math.abs(history[history.length - 1].score - history[history.length - 2].score);
+    evoState.converged = delta < SKILL_CONVERGENCE_THRESHOLD;
+  }
+  state.skillEvolution.set(skillOwnerId, evoState);
+  return null;
+}
+
 // --- Handlers ---
 
 export function handleRegister(
@@ -171,62 +249,13 @@ export function handleSendTask(
   }
 
   if (type === "skill_bundle") {
-    const pkg = parsedPayload as Partial<SkillPackage>;
-    if (!pkg.skillId || !pkg.name || !Array.isArray(pkg.artifacts)) {
-      return textResult({
-        error: "Skill bundle must include skillId, name, and artifacts array",
-      });
-    }
-    if (pkg.artifacts.length < MIN_SKILL_ARTIFACTS) {
-      return textResult({
-        error: `Skill packages must contain at least ${MIN_SKILL_ARTIFACTS} artifacts (EvoSkills multi-file constraint)`,
-        received: pkg.artifacts.length,
-        required: MIN_SKILL_ARTIFACTS,
-      });
-    }
-    const round = pkg.evolutionRound ?? 0;
-    if (round >= MAX_EVOLUTION_ROUNDS) {
-      return textResult({
-        error: `Skill has reached maximum evolution rounds (${MAX_EVOLUTION_ROUNDS})`,
-        currentRound: round,
-        maxRounds: MAX_EVOLUTION_ROUNDS,
-      });
-    }
-    // Initialize or update evolution state for the sender
-    const evoState = state.skillEvolution.get(from) ?? {
-      agentId: from,
-      currentRound: 0,
-      skillHistory: [],
-      converged: false,
-    };
-    evoState.currentRound = round;
-    state.skillEvolution.set(from, evoState);
+    const validationError = validateSkillBundle(state, from, parsedPayload);
+    if (validationError) return validationError;
   }
 
   if (type === "skill_verification") {
-    const ver = parsedPayload as Partial<SkillVerification>;
-    if (!ver.skillId || ver.pass === undefined || ver.score === undefined) {
-      return textResult({
-        error: "Skill verification must include skillId, pass, and score",
-      });
-    }
-    if (ver.score < 0 || ver.score > 1) {
-      return textResult({
-        error: "Verification score must be between 0 and 1",
-        received: ver.score,
-      });
-    }
-    // Update evolution state for the skill owner (the target agent)
-    const evoState = state.skillEvolution.get(to);
-    if (evoState) {
-      evoState.skillHistory.push({ skillId: ver.skillId, score: ver.score });
-      // Check convergence: last two scores within threshold
-      const history = evoState.skillHistory;
-      if (history.length >= 2) {
-        const delta = Math.abs(history[history.length - 1].score - history[history.length - 2].score);
-        evoState.converged = delta < SKILL_CONVERGENCE_THRESHOLD;
-      }
-    }
+    const validationError = validateSkillVerification(state, to, parsedPayload);
+    if (validationError) return validationError;
   }
 
   const task: Task = {

--- a/src/evoskills.test.ts
+++ b/src/evoskills.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for EvoSkills co-evolutionary skill evolution.
+ *
+ * Covers: skill_bundle validation, skill_verification validation,
+ * evolution state tracking, convergence detection, get_skill_status.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import type { BrokerState } from "./types.js";
+import { handleSendTask, handleGetSkillStatus } from "./broker.js";
+import {
+  createFreshState,
+  registerAgent,
+  makeSkillPackagePayload,
+  makeSkillVerificationPayload,
+} from "./test-helpers.js";
+
+function parse(result: { content: { type: string; text: string }[] }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("EvoSkills: skill_bundle validation", () => {
+  let state: BrokerState;
+
+  beforeEach(() => {
+    state = createFreshState();
+    registerAgent(state, "alice", "/project-a");
+    registerAgent(state, "bob", "/project-b");
+  });
+
+  it("accepts valid skill bundle", () => {
+    const result = parse(
+      handleSendTask(state, {
+        from: "alice",
+        to: "bob",
+        type: "skill_bundle",
+        payload: JSON.stringify(makeSkillPackagePayload("skill-001", 2, 0)),
+      }),
+    );
+
+    expect(result.sent).toBe(true);
+    expect(result.type).toBe("skill_bundle");
+  });
+
+  it("rejects skill bundle missing skillId", () => {
+    const result = parse(
+      handleSendTask(state, {
+        from: "alice",
+        to: "bob",
+        type: "skill_bundle",
+        payload: JSON.stringify({ name: "test", artifacts: [{ filename: "a.ts", content: "//", role: "entry" }, { filename: "b.ts", content: "//", role: "helper" }] }),
+      }),
+    );
+
+    expect(result.error).toMatch(/skillId/);
+  });
+
+  it("rejects skill bundle with too few artifacts", () => {
+    const result = parse(
+      handleSendTask(state, {
+        from: "alice",
+        to: "bob",
+        type: "skill_bundle",
+        payload: JSON.stringify(makeSkillPackagePayload("skill-001", 1, 0)),
+      }),
+    );
+
+    expect(result.error).toMatch(/at least.*artifacts/);
+    expect(result.received).toBe(1);
+  });
+
+  it("rejects skill bundle exceeding max evolution rounds", () => {
+    const result = parse(
+      handleSendTask(state, {
+        from: "alice",
+        to: "bob",
+        type: "skill_bundle",
+        payload: JSON.stringify(makeSkillPackagePayload("skill-001", 2, 5)),
+      }),
+    );
+
+    expect(result.error).toMatch(/maximum evolution rounds/);
+  });
+
+  it("accepts skill bundle at last valid round (round 4)", () => {
+    const result = parse(
+      handleSendTask(state, {
+        from: "alice",
+        to: "bob",
+        type: "skill_bundle",
+        payload: JSON.stringify(makeSkillPackagePayload("skill-001", 2, 4)),
+      }),
+    );
+
+    expect(result.sent).toBe(true);
+  });
+
+  it("initializes evolution state for sender on first bundle", () => {
+    handleSendTask(state, {
+      from: "alice",
+      to: "bob",
+      type: "skill_bundle",
+      payload: JSON.stringify(makeSkillPackagePayload("skill-001", 2, 0)),
+    });
+
+    const evoState = state.skillEvolution.get("alice");
+    expect(evoState).toBeDefined();
+    expect(evoState!.agentId).toBe("alice");
+    expect(evoState!.currentRound).toBe(0);
+  });
+});
+
+describe("EvoSkills: skill_verification validation", () => {
+  let state: BrokerState;
+
+  beforeEach(() => {
+    state = createFreshState();
+    registerAgent(state, "alice", "/project-a");
+    registerAgent(state, "bob", "/project-b");
+  });
+
+  it("accepts valid skill verification", () => {
+    const result = parse(
+      handleSendTask(state, {
+        from: "bob",
+        to: "alice",
+        type: "skill_verification",
+        payload: JSON.stringify(makeSkillVerificationPayload("skill-001", true, 0.85)),
+      }),
+    );
+
+    expect(result.sent).toBe(true);
+  });
+
+  it("rejects verification missing skillId", () => {
+    const result = parse(
+      handleSendTask(state, {
+        from: "bob",
+        to: "alice",
+        type: "skill_verification",
+        payload: JSON.stringify({ pass: true, score: 0.5, feedback: "ok", testCases: [] }),
+      }),
+    );
+
+    expect(result.error).toMatch(/skillId/);
+  });
+
+  it("rejects verification with out-of-range score", () => {
+    const result = parse(
+      handleSendTask(state, {
+        from: "bob",
+        to: "alice",
+        type: "skill_verification",
+        payload: JSON.stringify(makeSkillVerificationPayload("skill-001", true, 1.5)),
+      }),
+    );
+
+    expect(result.error).toMatch(/between 0 and 1/);
+  });
+
+  it("initializes evolution state for skill owner on first verification", () => {
+    // Verification arrives before skill owner has sent a bundle
+    handleSendTask(state, {
+      from: "bob",
+      to: "alice",
+      type: "skill_verification",
+      payload: JSON.stringify(makeSkillVerificationPayload("skill-001", true, 0.7)),
+    });
+
+    const evoState = state.skillEvolution.get("alice");
+    expect(evoState).toBeDefined();
+    expect(evoState!.skillHistory).toHaveLength(1);
+    expect(evoState!.skillHistory[0].score).toBe(0.7);
+  });
+
+  it("accumulates verification history on skill owner", () => {
+    // Alice sends bundle, Bob verifies twice
+    handleSendTask(state, {
+      from: "alice",
+      to: "bob",
+      type: "skill_bundle",
+      payload: JSON.stringify(makeSkillPackagePayload("skill-001", 2, 0)),
+    });
+
+    handleSendTask(state, {
+      from: "bob",
+      to: "alice",
+      type: "skill_verification",
+      payload: JSON.stringify(makeSkillVerificationPayload("skill-001", false, 0.4)),
+    });
+
+    handleSendTask(state, {
+      from: "bob",
+      to: "alice",
+      type: "skill_verification",
+      payload: JSON.stringify(makeSkillVerificationPayload("skill-001", true, 0.85)),
+    });
+
+    const evoState = state.skillEvolution.get("alice");
+    expect(evoState!.skillHistory).toHaveLength(2);
+    expect(evoState!.converged).toBe(false); // 0.4 -> 0.85 = delta 0.45
+  });
+});
+
+describe("EvoSkills: convergence detection", () => {
+  let state: BrokerState;
+
+  beforeEach(() => {
+    state = createFreshState();
+    registerAgent(state, "alice", "/project-a");
+    registerAgent(state, "bob", "/project-b");
+  });
+
+  it("detects convergence when scores stabilize", () => {
+    handleSendTask(state, {
+      from: "alice",
+      to: "bob",
+      type: "skill_bundle",
+      payload: JSON.stringify(makeSkillPackagePayload("skill-001", 2, 0)),
+    });
+
+    // First verification
+    handleSendTask(state, {
+      from: "bob",
+      to: "alice",
+      type: "skill_verification",
+      payload: JSON.stringify(makeSkillVerificationPayload("skill-001", true, 0.90)),
+    });
+
+    // Second verification with similar score (delta < 0.05)
+    handleSendTask(state, {
+      from: "bob",
+      to: "alice",
+      type: "skill_verification",
+      payload: JSON.stringify(makeSkillVerificationPayload("skill-001", true, 0.92)),
+    });
+
+    const evoState = state.skillEvolution.get("alice");
+    expect(evoState!.converged).toBe(true);
+  });
+
+  it("does not converge when scores diverge", () => {
+    handleSendTask(state, {
+      from: "alice",
+      to: "bob",
+      type: "skill_bundle",
+      payload: JSON.stringify(makeSkillPackagePayload("skill-001", 2, 0)),
+    });
+
+    handleSendTask(state, {
+      from: "bob",
+      to: "alice",
+      type: "skill_verification",
+      payload: JSON.stringify(makeSkillVerificationPayload("skill-001", true, 0.5)),
+    });
+
+    handleSendTask(state, {
+      from: "bob",
+      to: "alice",
+      type: "skill_verification",
+      payload: JSON.stringify(makeSkillVerificationPayload("skill-001", true, 0.9)),
+    });
+
+    const evoState = state.skillEvolution.get("alice");
+    expect(evoState!.converged).toBe(false);
+  });
+});
+
+describe("EvoSkills: get_skill_status", () => {
+  let state: BrokerState;
+
+  beforeEach(() => {
+    state = createFreshState();
+    registerAgent(state, "alice", "/project-a");
+    registerAgent(state, "bob", "/project-b");
+  });
+
+  it("returns hint when no evolution state exists", () => {
+    const result = parse(handleGetSkillStatus(state, { agentId: "alice" }));
+
+    expect(result.hasSkillEvolution).toBe(false);
+    expect(result.hint).toBeDefined();
+  });
+
+  it("returns evolution state after skill bundle", () => {
+    handleSendTask(state, {
+      from: "alice",
+      to: "bob",
+      type: "skill_bundle",
+      payload: JSON.stringify(makeSkillPackagePayload("skill-001", 2, 0)),
+    });
+
+    const result = parse(handleGetSkillStatus(state, { agentId: "alice" }));
+
+    expect(result.hasSkillEvolution).toBe(true);
+    expect(result.currentRound).toBe(0);
+    expect(result.converged).toBe(false);
+  });
+
+  it("errors for unregistered agent", () => {
+    const result = parse(handleGetSkillStatus(state, { agentId: "unknown" }));
+    expect(result.error).toMatch(/not registered/);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,12 +4,15 @@
  *
  * An MCP server that enables two Claude Code instances to review each other's
  * projects through structured artifact exchange. Design informed by QSG scaling
- * laws (Tanaka, arXiv:2603.24676):
+ * laws (Tanaka, arXiv:2603.24676) and EvoSkills co-evolutionary verification
+ * (Zhang et al., arXiv:2604.01687):
  *
- *   Γ_h = mN·h/α  — drift-selection parameter
+ *   Γ_h = mN·h/α  — drift-selection parameter (QSG)
+ *   Skill Generator ↔ Surrogate Verifier co-evolution (EvoSkills)
  *
- * High bandwidth (m ≥ 3 findings per bundle) pushes the system into the
+ * High bandwidth (m ≥ 5 findings per bundle) pushes the system into the
  * selection regime where genuine insights dominate over random drift.
+ * Skill packages evolve through iterative refinement capped at 5 rounds.
  */
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
@@ -22,6 +25,8 @@ import {
   type BrokerState,
   type FindingResponse,
   MIN_BANDWIDTH,
+  MAX_EVOLUTION_ROUNDS,
+  MIN_SKILL_ARTIFACTS,
 } from "./types.js";
 import {
   handleRegister,
@@ -32,6 +37,7 @@ import {
   handleWaitForPhase,
   handleGetStatus,
   handleDeregister,
+  handleGetSkillStatus,
 } from "./broker.js";
 import type { MemPalaceState } from "./types.js";
 import {
@@ -65,6 +71,7 @@ const state: BrokerState = {
   taskQueues: new Map(),
   phaseWaiters: new Map(),
   sentTaskTypes: new Map(),
+  skillEvolution: new Map(),
 };
 
 const memPalaceState: MemPalaceState = createMemPalaceState();
@@ -80,12 +87,28 @@ Central formula: **Γ_h = mN·h/α** where m=findings per bundle, N=agents, h=bi
 - |Γ_h| ≫ 1 → genuine insights amplified (selection regime)
 - Design: m ≥ ${MIN_BANDWIDTH} keeps Γ_h ≈ 1.67 in the selection regime
 
+## EvoSkills Integration (Zhang et al., 2026, arXiv:2604.01687)
+Agents can exchange **skill packages** — multi-file artifact bundles that encode
+reusable task strategies. The two-agent cross-review topology maps onto the
+EvoSkills co-evolutionary loop:
+- **Agent A** acts as Skill Generator, submitting a skill_bundle to Agent B
+- **Agent B** acts as Surrogate Verifier, returning a skill_verification with score and feedback
+- Agent A refines the skill using feedback (up to ${MAX_EVOLUTION_ROUNDS} rounds)
+- Convergence is detected when consecutive scores stabilize
+
+Constraints:
+- Skill packages must contain ≥ ${MIN_SKILL_ARTIFACTS} artifacts (multi-file requirement)
+- Evolution is capped at ${MAX_EVOLUTION_ROUNDS} rounds (empirically sufficient per Zhang et al.)
+- Skills evolved by one agent transfer effectively to others (cross-model portability)
+
 ## Phases (sequential, enforced by broker)
 1. **briefing** — Read own codebase, produce structured Briefing artifact, send to peer. Both agents do this in parallel.
 2. **review** — Wait for peer briefing (wait_for_phase), read peer's actual code, send Finding[] bundle (m ≥ ${MIN_BANDWIDTH}). Must have sent a briefing first.
 3. **dialogue** — Read findings about own project, respond with FindingResponse[] verdicts. Must have sent a review_bundle first.
 4. **synthesis** — Produce a Synthesis artifact: accepted findings with planned actions, rejected findings with reasons. Must have sent a response first. Each agent synthesizes what it learned about its own project.
 5. **complete** — All findings processed and synthesized. Signal completion.
+
+Skill exchange (skill_bundle / skill_verification) can happen during any phase after briefing.
 
 ## Finding Categories
 pattern_transfer, missing_practice, inconsistency, simplification, bug_risk, documentation_gap
@@ -123,11 +146,11 @@ function createBrokerServer(brokerState: BrokerState, mpState: MemPalaceState): 
   // Tool: send_task
   server.tool(
     "send_task",
-    "Send a task (briefing, review bundle, question, or response) to a peer agent. Review bundles must contain at least 5 findings (QSG bandwidth constraint: Γ_h ≈ 1.67).",
+    "Send a task to a peer agent. Review bundles must contain ≥ 5 findings (QSG). Skill bundles must contain ≥ 2 artifacts (EvoSkills) and evolve for up to 5 rounds.",
     {
       from: z.string().describe("Your agent ID (the sender)"),
       to: z.string().describe("Target agent ID"),
-      type: z.enum(["briefing", "review_bundle", "question", "response", "synthesis"]).describe("Task type"),
+      type: z.enum(["briefing", "review_bundle", "question", "response", "synthesis", "skill_bundle", "skill_verification"]).describe("Task type"),
       payload: z.string().describe("JSON-encoded payload matching the task type schema"),
     },
     async (args) => {
@@ -150,6 +173,14 @@ function createBrokerServer(brokerState: BrokerState, mpState: MemPalaceState): 
               logEvent({ event: "verdict", taskId: parsed.taskId, from: args.from, to: args.to, findingId: response.findingId, verdict: response.verdict });
             }
           }
+        } else if (args.type === "skill_bundle") {
+          let parsedPayload: Record<string, unknown>;
+          try { parsedPayload = JSON.parse(args.payload); } catch { parsedPayload = {}; }
+          logEvent({ event: "skill_bundle", taskId: parsed.taskId, from: args.from, to: args.to, skillId: parsedPayload.skillId, evolutionRound: parsedPayload.evolutionRound, artifactCount: Array.isArray(parsedPayload.artifacts) ? parsedPayload.artifacts.length : 0 });
+        } else if (args.type === "skill_verification") {
+          let parsedPayload: Record<string, unknown>;
+          try { parsedPayload = JSON.parse(args.payload); } catch { parsedPayload = {}; }
+          logEvent({ event: "skill_verification", taskId: parsed.taskId, from: args.from, to: args.to, skillId: parsedPayload.skillId, pass: parsedPayload.pass, score: parsedPayload.score });
         }
       }
 
@@ -219,6 +250,16 @@ function createBrokerServer(brokerState: BrokerState, mpState: MemPalaceState): 
     "Get the current broker state: registered agents, their phases, and pending task counts.",
     {},
     async () => handleGetStatus(brokerState)
+  );
+
+  // Tool: get_skill_status (EvoSkills)
+  server.tool(
+    "get_skill_status",
+    "Get the skill evolution state for an agent: current round, convergence status, score history.",
+    {
+      agentId: z.string().describe("The agent ID to query skill evolution for"),
+    },
+    async (args) => handleGetSkillStatus(brokerState, args)
   );
 
   // Tool: deregister
@@ -377,6 +418,7 @@ export async function startTestServer(): Promise<{ url: string; close: () => Pro
     taskQueues: new Map(),
     phaseWaiters: new Map(),
     sentTaskTypes: new Map(),
+    skillEvolution: new Map(),
   };
   const testTransports = new Map<string, StreamableHTTPServerTransport>();
   const testMpState = createMemPalaceState();

--- a/src/server.ts
+++ b/src/server.ts
@@ -174,13 +174,12 @@ function createBrokerServer(brokerState: BrokerState, mpState: MemPalaceState): 
             }
           }
         } else if (args.type === "skill_bundle") {
-          let parsedPayload: Record<string, unknown>;
-          try { parsedPayload = JSON.parse(args.payload); } catch { parsedPayload = {}; }
-          logEvent({ event: "skill_bundle", taskId: parsed.taskId, from: args.from, to: args.to, skillId: parsedPayload.skillId, evolutionRound: parsedPayload.evolutionRound, artifactCount: Array.isArray(parsedPayload.artifacts) ? parsedPayload.artifacts.length : 0 });
+          // Payload already validated by handleSendTask — safe to parse
+          const skillPayload = JSON.parse(args.payload) as Record<string, unknown>;
+          logEvent({ event: "skill_bundle", taskId: parsed.taskId, from: args.from, to: args.to, skillId: skillPayload.skillId, evolutionRound: skillPayload.evolutionRound, artifactCount: Array.isArray(skillPayload.artifacts) ? skillPayload.artifacts.length : 0 });
         } else if (args.type === "skill_verification") {
-          let parsedPayload: Record<string, unknown>;
-          try { parsedPayload = JSON.parse(args.payload); } catch { parsedPayload = {}; }
-          logEvent({ event: "skill_verification", taskId: parsed.taskId, from: args.from, to: args.to, skillId: parsedPayload.skillId, pass: parsedPayload.pass, score: parsedPayload.score });
+          const verPayload = JSON.parse(args.payload) as Record<string, unknown>;
+          logEvent({ event: "skill_verification", taskId: parsed.taskId, from: args.from, to: args.to, skillId: verPayload.skillId, pass: verPayload.pass, score: verPayload.score });
         }
       }
 

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -18,6 +18,7 @@ export function createFreshState(): BrokerState {
     taskQueues: new Map(),
     phaseWaiters: new Map(),
     sentTaskTypes: new Map(),
+    skillEvolution: new Map(),
   };
 }
 
@@ -82,4 +83,44 @@ export function makeResponsePayload(count: number): object[] {
     verdict: "accept",
     evidence: `Response evidence ${i}`,
   }));
+}
+
+/**
+ * Build a minimal valid SkillPackage payload.
+ */
+export function makeSkillPackagePayload(
+  skillId = "skill-001",
+  artifactCount = 2,
+  evolutionRound = 0,
+): object {
+  return {
+    skillId,
+    name: `Test Skill ${skillId}`,
+    description: "A test skill package",
+    artifacts: Array.from({ length: artifactCount }, (_, i) => ({
+      filename: i === 0 ? "index.ts" : `helper-${i}.ts`,
+      content: `// artifact ${i}`,
+      role: i === 0 ? "entry" : "helper",
+    })),
+    evolutionRound,
+  };
+}
+
+/**
+ * Build a minimal valid SkillVerification payload.
+ */
+export function makeSkillVerificationPayload(
+  skillId = "skill-001",
+  pass = true,
+  score = 0.85,
+): object {
+  return {
+    skillId,
+    pass,
+    score,
+    feedback: pass ? "Skill meets requirements" : "Skill needs improvement",
+    testCases: [
+      { input: "test input", expectedBehavior: "expected output", passed: pass },
+    ],
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,12 @@
  * - Finding bundles enforce bandwidth m ≥ 3 to stay in the selection regime
  * - Response verdicts with evidence structurally enforce α < 1
  * - Phase signaling prevents premature consensus
+ *
+ * EvoSkills integration (Zhang et al., 2026, arXiv:2604.01687):
+ * - Skill Generator ↔ Surrogate Verifier co-evolution maps onto
+ *   the two-agent cross-review architecture
+ * - Multi-file skill packages exchanged as structured artifacts
+ * - Iterative refinement bounded by MAX_EVOLUTION_ROUNDS
  */
 
 // --- Phase lifecycle ---
@@ -99,16 +105,55 @@ export interface FindingResponse {
   counterEvidence?: string;
 }
 
+// --- EvoSkills: Skill packages (Zhang et al., 2026) ---
+
+export interface SkillArtifact {
+  filename: string;
+  content: string;
+  role: "entry" | "helper" | "config" | "test";
+}
+
+export interface SkillPackage {
+  skillId: string;
+  name: string;
+  description: string;
+  artifacts: SkillArtifact[];
+  evolutionRound: number;
+  parentSkillId?: string;
+}
+
+export interface SkillVerification {
+  skillId: string;
+  pass: boolean;
+  score: number;
+  feedback: string;
+  testCases: SkillTestCase[];
+}
+
+export interface SkillTestCase {
+  input: string;
+  expectedBehavior: string;
+  passed: boolean;
+  observation?: string;
+}
+
+export interface SkillEvolutionState {
+  agentId: string;
+  currentRound: number;
+  skillHistory: { skillId: string; score: number }[];
+  converged: boolean;
+}
+
 // --- Task envelope ---
 
-export type TaskType = "briefing" | "review_bundle" | "question" | "response" | "synthesis";
+export type TaskType = "briefing" | "review_bundle" | "question" | "response" | "synthesis" | "skill_bundle" | "skill_verification";
 
 export interface Task {
   id: string;
   from: string;
   to: string;
   type: TaskType;
-  payload: Briefing | Finding[] | Question | FindingResponse[] | Synthesis;
+  payload: Briefing | Finding[] | Question | FindingResponse[] | Synthesis | SkillPackage | SkillVerification;
   createdAt: number;
 }
 
@@ -128,6 +173,8 @@ export interface BrokerState {
   phaseWaiters: Map<string, PhaseWaiter[]>;
   /** Track task types each agent has sent, for phase precondition checks. */
   sentTaskTypes: Map<string, Set<TaskType>>;
+  /** EvoSkills: per-agent skill evolution state. */
+  skillEvolution: Map<string, SkillEvolutionState>;
 }
 
 export interface PhaseWaiter {
@@ -146,6 +193,22 @@ export interface PhaseWaiter {
  * without raising this constant degrades selection pressure.
  */
 export const MIN_BANDWIDTH = 5;
+
+/**
+ * EvoSkills co-evolutionary constants (Zhang et al., 2026).
+ *
+ * MAX_EVOLUTION_ROUNDS: Paper shows skills surpass human-curated
+ * quality within 5 iterations; capping prevents runaway loops.
+ *
+ * MIN_SKILL_ARTIFACTS: Skills are multi-file packages by definition;
+ * a single file is just a script, not a composable skill.
+ *
+ * SKILL_CONVERGENCE_THRESHOLD: When consecutive verification scores
+ * differ by less than this, the skill is considered converged.
+ */
+export const MAX_EVOLUTION_ROUNDS = 5;
+export const MIN_SKILL_ARTIFACTS = 2;
+export const SKILL_CONVERGENCE_THRESHOLD = 0.05;
 
 // --- MemPalace integration ---
 


### PR DESCRIPTION
Integrate EvoSkills framework alongside existing QSG scaling laws. Agents can
now exchange multi-file skill packages and co-evolve them through iterative
surrogate verification, capped at 5 rounds with convergence detection.

- Add SkillPackage, SkillVerification, SkillEvolutionState types
- Add skill_bundle and skill_verification task types with validation
- Add get_skill_status MCP tool for querying evolution state
- Add EvoSkills constants (MAX_EVOLUTION_ROUNDS, MIN_SKILL_ARTIFACTS)
- Update protocol doc and CLAUDE.md with EvoSkills documentation
- Add test helpers for skill package and verification payloads

https://claude.ai/code/session_019QesWyRXdfbyfzZxWYwZwy